### PR TITLE
feat: add Glo Dollar token to CELO_TOKENS list

### DIFF
--- a/src/types/tokens.ts
+++ b/src/types/tokens.ts
@@ -94,6 +94,13 @@ export const CELO_TOKENS: Token[] = [
     decimals: 18,
     address: '0x765de816845861e75a25fca122bb6898b8b1282a',
     logoUrl: 'https://celoscan.io/token/images/celodollar_32.png'
+  },
+  {
+    symbol: 'USDGLO',
+    name: 'Glo Dollar',
+    decimals: 18,
+    address: '0x4f604735c1cf31399c6e711d5962b2b3e0225ad3',
+    logoUrl: 'https://avatars.githubusercontent.com/u/131250622?s=48&v=4'
   }
 ]
 


### PR DESCRIPTION
This pull request includes a small change to the `src/types/tokens.ts` file. The change adds a new token, 'Glo Dollar', to the `CELO_TOKENS` array.

* [`src/types/tokens.ts`](diffhunk://#diff-2b2463723699e5eff32e6cfea291d57f8f931d4be0e9e204da643b66b2bb576dR97-R103): Added 'Glo Dollar' token with symbol 'USDGLO', including its name, decimals, address, and logo URL.